### PR TITLE
[CFRS-71] 대기실에서 실시간 공부방 접속인원 확인 기능 구현

### DIFF
--- a/src/constants/room.constant.ts
+++ b/src/constants/room.constant.ts
@@ -1,6 +1,7 @@
 import { Range } from "@/models/common/Range";
 
-export const MAX_ROOM_PEOPLE_NUMBER = 4;
+// TODO: socket server와 중복되는 값, 한곳에서 통일 필요
+export const MAX_ROOM_CAPACITY = 4;
 
 export const POMODORO_TIMER_RANGE: Range = new Range(20, 50);
 export const POMODORO_SHORT_BREAK_RANGE: Range = new Range(3, 10);

--- a/src/constants/socketProtocol.ts
+++ b/src/constants/socketProtocol.ts
@@ -32,6 +32,11 @@ const CONNECTION_SUCCESS = "connection-success";
 const DISCONNECT = "disconnect";
 
 /**
+ * 방 접속 준비화면에 초기정보를 전달하기 위한 프로토콜이다.
+ */
+const CONNECT_WAITING_ROOM = "ready-to-join-room";
+
+/**
  * 방 참여를 요청하는 프로토콜이다.
  *
  * 클라이언트에서 서버로 전송된다.
@@ -132,6 +137,7 @@ export {
   CONNECTION,
   CONNECTION_SUCCESS,
   DISCONNECT,
+  CONNECT_WAITING_ROOM,
   JOIN_ROOM,
   CREATE_WEB_RTC_TRANSPORT,
   TRANSPORT_PRODUCER,

--- a/src/constants/socketProtocol.ts
+++ b/src/constants/socketProtocol.ts
@@ -37,6 +37,16 @@ const DISCONNECT = "disconnect";
 const CONNECT_WAITING_ROOM = "ready-to-join-room";
 
 /**
+ * 다른 회원이 공부방에 접속했을 때 대기실에 있는 회원들에게 알리기 위한 프로토콜이다.
+ */
+const OTHER_PEER_JOINED_ROOM = "other-peer-joined-room";
+
+/**
+ * 다른 회원이 공부방에서 나갔을 때 대기실에 있는 회원들에게 알리기 위한 프로토콜이다.
+ */
+const OTHER_PEER_EXITED_ROOM = "other-peer-exited-room";
+
+/**
  * 방 참여를 요청하는 프로토콜이다.
  *
  * 클라이언트에서 서버로 전송된다.
@@ -138,6 +148,8 @@ export {
   CONNECTION_SUCCESS,
   DISCONNECT,
   CONNECT_WAITING_ROOM,
+  OTHER_PEER_JOINED_ROOM,
+  OTHER_PEER_EXITED_ROOM,
   JOIN_ROOM,
   CREATE_WEB_RTC_TRANSPORT,
   TRANSPORT_PRODUCER,

--- a/src/models/room/RoomJoiner.ts
+++ b/src/models/room/RoomJoiner.ts
@@ -1,0 +1,5 @@
+// TODO: socket server와 중복되는 인터페이스라 한군데서 관리할 수 있도록 해야함
+export interface RoomJoiner {
+  readonly id: string;
+  readonly name: string;
+}

--- a/src/models/room/RoomState.ts
+++ b/src/models/room/RoomState.ts
@@ -1,5 +1,6 @@
 export enum RoomState {
   CREATED,
   CONNECTED,
+  WAITING_ROOM,
   JOINED,
 }

--- a/src/models/room/WaitingRoomData.ts
+++ b/src/models/room/WaitingRoomData.ts
@@ -1,8 +1,20 @@
 import { RoomJoiner } from "@/models/room/RoomJoiner";
 
 // TODO: socket server와 중복되는 인터페이스라 한군데서 관리할 수 있도록 해야함
+// TODO: Interface 이름 명확하지 않아 헷갈릴 수 있음
 export interface WaitingRoomData {
-  joinerList: RoomJoiner[];
-  capacity: number;
-  masterId: string;
+  /**
+   * 공부방에 참여한 사람들의 목록이다.
+   */
+  readonly joinerList: RoomJoiner[];
+
+  /**
+   * 공부방의 최대 참여 가능한 인원이다.
+   */
+  readonly capacity: number;
+
+  /**
+   * 공부방의 방장 ID이다.
+   */
+  readonly masterId: string;
 }

--- a/src/models/room/WaitingRoomData.ts
+++ b/src/models/room/WaitingRoomData.ts
@@ -1,0 +1,8 @@
+import { RoomJoiner } from "@/models/room/RoomJoiner";
+
+// TODO: socket server와 중복되는 인터페이스라 한군데서 관리할 수 있도록 해야함
+export interface WaitingRoomData {
+  joinerList: RoomJoiner[];
+  capacity: number;
+  masterId: string;
+}

--- a/src/models/room/WaitingRoomEvent.ts
+++ b/src/models/room/WaitingRoomEvent.ts
@@ -1,0 +1,15 @@
+import { RoomJoiner } from "@/models/room/RoomJoiner";
+
+export abstract class WaitingRoomEvent {}
+
+export class OtherPeerJoinedRoomEvent extends WaitingRoomEvent {
+  constructor(readonly joiner: RoomJoiner) {
+    super();
+  }
+}
+
+export class OtherPeerExitedRoomEvent extends WaitingRoomEvent {
+  constructor(readonly exitedUserId: string) {
+    super();
+  }
+}

--- a/src/pages/rooms/[roomId].tsx
+++ b/src/pages/rooms/[roomId].tsx
@@ -63,6 +63,18 @@ const WaitingRoom: NextPage<{
         입장
       </button>
       <div>{roomStore.waitingRoomMessage}</div>
+
+      <div>
+        <div>방 참여자 목록</div>
+        {roomStore.roomJoiners.map((joiner) => {
+          return (
+            <div key={joiner.id} style={{ padding: "8px" }}>
+              <UserProfileImage userId={joiner.id} />
+              {joiner.name}
+            </div>
+          );
+        })}
+      </div>
     </>
   );
 });

--- a/src/pages/rooms/[roomId].tsx
+++ b/src/pages/rooms/[roomId].tsx
@@ -62,6 +62,7 @@ const WaitingRoom: NextPage<{
       >
         입장
       </button>
+      <div>{roomStore.waitingRoomMessage}</div>
     </>
   );
 });

--- a/src/repository/room.repository.ts
+++ b/src/repository/room.repository.ts
@@ -1,6 +1,6 @@
 import prisma from "../../prisma/client";
 import { room } from "@prisma/client";
-import { MAX_ROOM_PEOPLE_NUMBER } from "@/constants/room.constant";
+import { MAX_ROOM_CAPACITY } from "@/constants/room.constant";
 
 export const findRoomById = async (roomId: string): Promise<room | null> => {
   return await prisma.room.findUnique({
@@ -17,7 +17,7 @@ export const isRoomFull = async (roomId: string): Promise<boolean> => {
       exit_at: undefined,
     },
   });
-  return histories.length === MAX_ROOM_PEOPLE_NUMBER;
+  return histories.length === MAX_ROOM_CAPACITY;
 };
 
 export const isUserBlockedAtRoom = async (

--- a/src/stores/RoomStore.ts
+++ b/src/stores/RoomStore.ts
@@ -197,6 +197,7 @@ export class RoomStore implements RoomViewModel {
       this._waitingRoomData = {
         ...waitingRoomData,
         joinerList: waitingRoomData.joinerList.filter(
+          // TODO: 현재 동일한 회원이 하나의 방에 여러번 접속하는 경우 퇴장할 때 대기실의 동일한 참여자 목록이 제거되는 버그 존재. CFRS-84 에서 해결 될 것임
           (joiner) => joiner.id !== event.exitedUserId
         ),
       };

--- a/src/stores/RoomStore.ts
+++ b/src/stores/RoomStore.ts
@@ -72,16 +72,39 @@ export class RoomStore implements RoomViewModel {
     return this._localAudioStream !== undefined;
   }
 
+  private _isCurrentUserMaster = (
+    waitingRoomData: WaitingRoomData
+  ): boolean => {
+    // TODO: auth대신 UserStore로 변경하기
+    return waitingRoomData.masterId === auth.currentUser?.uid;
+  };
+
+  private _isRoomFull = (waitingRoomData: WaitingRoomData): boolean => {
+    return waitingRoomData.joinerList.length >= waitingRoomData.capacity;
+  };
+
+  public get waitingRoomMessage(): string | undefined {
+    const waitingRoomData = this._waitingRoomData;
+    if (waitingRoomData === undefined) {
+      return "연결 중...";
+    }
+    if (this._isCurrentUserMaster(waitingRoomData)) {
+      return undefined;
+    }
+    if (this._isRoomFull(waitingRoomData)) {
+      return "방 정원이 가득 찼습니다.";
+    }
+  }
+
   public get canJoinRoom(): boolean {
     const waitingRoomData = this._waitingRoomData;
     if (waitingRoomData === undefined) {
       return false;
     }
-    // TODO: auth대신 UserStore로 변경하기
-    if (waitingRoomData.masterId === auth.currentUser?.uid) {
+    if (this._isCurrentUserMaster(waitingRoomData)) {
       return true;
     }
-    return waitingRoomData.joinerList.length < waitingRoomData.capacity;
+    return !this._isRoomFull(waitingRoomData);
   }
 
   public get remoteVideoStreamByPeerIdEntries(): [string, MediaStream][] {

--- a/test/room.controller.test.ts
+++ b/test/room.controller.test.ts
@@ -3,7 +3,7 @@ import { room } from "@prisma/client";
 import { getRoomAvailability } from "@/controller/room.controller";
 import { NextApiRequest, NextApiResponse } from "next";
 import { instance, mock, verify, when } from "ts-mockito";
-import { MAX_ROOM_PEOPLE_NUMBER } from "@/constants/room.constant";
+import { MAX_ROOM_CAPACITY } from "@/constants/room.constant";
 
 describe("getRoomAvailability", () => {
   const mockRoom: room = {
@@ -62,7 +62,7 @@ describe("getRoomAvailability", () => {
     const room = { ...mockRoom, master_id: uid };
     mockPrisma.room.findUnique.mockResolvedValue(room);
     mockPrisma.study_history.findMany.mockResolvedValue([
-      ...Array(MAX_ROOM_PEOPLE_NUMBER),
+      ...Array(MAX_ROOM_CAPACITY),
     ]);
     mockPrisma.block.findUnique.mockResolvedValue(null);
     const request = createMockRequest({
@@ -112,7 +112,7 @@ describe("getRoomAvailability", () => {
     // when
     mockPrisma.room.findUnique.mockResolvedValue(mockRoom);
     mockPrisma.study_history.findMany.mockResolvedValue([
-      ...new Array(MAX_ROOM_PEOPLE_NUMBER),
+      ...new Array(MAX_ROOM_CAPACITY),
     ]);
     mockPrisma.block.findUnique.mockResolvedValue(null);
     const request = createMockRequest({


### PR DESCRIPTION
- 공부방에 접속한 인원이 가득 차있는 경우 대기실의 입장 버튼 비활성화
- 공부방에 입/퇴장 할때마다 실시간으로 대기실에 보이는 접속인원 갱신됨

서버 PR: https://github.com/Foundy-LLC/camstudy-webrtc-server/pull/5


https://user-images.githubusercontent.com/57604817/217474559-831016b2-bf09-432e-aa17-41d41a5f32df.mov

