### PR TITLE
[CFRS-97] WebRTC 네이밍 리팩토링 및 안정성 개선

### DIFF
--- a/src/service/RoomSocketService.ts
+++ b/src/service/RoomSocketService.ts
@@ -208,6 +208,9 @@ export class RoomSocketService {
       OTHER_PEER_DISCONNECTED,
       ({ disposedPeerId }: { disposedPeerId: string }) => {
         this._roomViewModel.onDisposedPeer(disposedPeerId);
+        this._receiveTransportWrappers = this._receiveTransportWrappers.filter(
+          (wrapper) => wrapper.userId !== disposedPeerId
+        );
       }
     );
     socket.on(PRODUCER_CLOSED, ({ remoteProducerId }) => {

--- a/src/service/RoomSocketService.ts
+++ b/src/service/RoomSocketService.ts
@@ -67,6 +67,14 @@ interface ConsumeParams {
   readonly serverConsumerId: string;
 }
 
+interface ReceiveTransportWrapper {
+  receiveTransport: Transport;
+  serverReceiveTransportId: string;
+  producerId: string;
+  userId: string;
+  consumer: Consumer;
+}
+
 interface ErrorParams {
   error: any;
 }
@@ -79,13 +87,7 @@ export class RoomSocketService {
   private _videoProducer?: Producer;
 
   private readonly _consumingTransportIds: Set<string> = new Set();
-  private _receiveTransports: {
-    receiveTransport: Transport;
-    serverReceiveTransportId: string;
-    producerId: string;
-    userId: string;
-    consumer: Consumer;
-  }[] = [];
+  private _receiveTransportWrappers: ReceiveTransportWrapper[] = [];
 
   constructor(private readonly _roomViewModel: RoomViewModel) {}
 
@@ -211,7 +213,7 @@ export class RoomSocketService {
     socket.on(PRODUCER_CLOSED, ({ remoteProducerId }) => {
       // server notification is received when a producer is closed
       // we need to close the client-side consumer and associated transport
-      const receiveTransport = this._receiveTransports.find(
+      const receiveTransport = this._receiveTransportWrappers.find(
         (transportData) => transportData.producerId === remoteProducerId
       );
       if (receiveTransport === undefined) {
@@ -481,8 +483,8 @@ export class RoomSocketService {
         // then consume with the local consumer transport
         // which creates a consumer
         const consumer = await receiveTransport.consume(params);
-        this._receiveTransports = [
-          ...this._receiveTransports,
+        this._receiveTransportWrappers = [
+          ...this._receiveTransportWrappers,
           {
             userId,
             receiveTransport,

--- a/src/service/RoomSocketService.ts
+++ b/src/service/RoomSocketService.ts
@@ -366,7 +366,8 @@ export class RoomSocketService {
           // server side producer's id.
           callback({ id });
           // if producers exist, then join room
-          if (producersExist) this._getProducersAndConsume(device);
+          if (producersExist)
+            this._getRemoteProducersAndCreateReceiveTransport(device);
         }
       );
     } catch (error: any) {
@@ -374,7 +375,7 @@ export class RoomSocketService {
     }
   };
 
-  private _getProducersAndConsume = (device: Device) => {
+  private _getRemoteProducersAndCreateReceiveTransport = (device: Device) => {
     this._requireSocket().emit(
       GET_PRODUCER_IDS,
       (userProducerIds: { producerId: string; userId: string }[]) => {


### PR DESCRIPTION
- 기존 consumerTransport or producerTransport에서 mediasoup 문서에 정의된 receiveTransport, sendTransport로 네이밍을 수정했습니다.
- 코드 가독성을 개선했습니다.
- 이미 다른 피어의 생산 포트와 연결된 소비 포트가 필요할 때 기존에 이미 만들어진 소비 포트가 있는 경우 이를 재사용하도록 수정했습니다. 그 이유는 기존에는 소비자 하나당 소비 포트 하나라 오버헤드가 발생할 것이라 생각했기 때문입니다. 즉, 오디오 소비자에 소비 포트 하나, 비디오 소비자에 소비포트 하나였습니다. 수정 후에는 소비포트 하나에 오디오, 비디오 소비자가 생성됩니다.

https://github.com/Foundy-LLC/camstudy-webrtc-server/pull/8