### PR TITLE
Result 클래스 리팩토링

### DIFF
--- a/src/models/common/Result.ts
+++ b/src/models/common/Result.ts
@@ -1,18 +1,18 @@
 import { ResponseBody } from "@/models/common/ResponseBody";
 
+class Failure {
+  constructor(public error: Error) {}
+}
+
 export class Result<T> {
-  private constructor(
-    private _data?: T,
-    private _error?: Error,
-    private _isError: boolean = false
-  ) {}
+  private constructor(private _data?: T) {}
 
   static success<T>(data: T): Result<T> {
-    return new Result(data, undefined, false);
+    return new Result(data);
   }
 
   static error<T>(e: Error): Result<T> {
-    return new Result<any>(undefined, e, true);
+    return new Result<any>(new Failure(e));
   }
 
   public static async parseToResponseBody<T>(
@@ -58,15 +58,25 @@ export class Result<T> {
     return Result.error(Error("알 수 없는 에러가 발생했습니다."));
   }
 
-  public get isSuccess() {
-    return !this._isError;
+  public get isSuccess(): boolean {
+    return !this.isFailure;
+  }
+
+  public get isFailure(): boolean {
+    return this._data instanceof Failure;
   }
 
   public getOrNull = (): T | undefined => {
-    return this._data;
+    if (this.isSuccess) {
+      return this._data;
+    }
+    return undefined;
   };
 
   public throwableOrNull = (): Error | undefined => {
-    return this._error;
+    if (this._data instanceof Failure) {
+      return this._data.error;
+    }
+    return undefined;
   };
 }

--- a/test/Result.test.ts
+++ b/test/Result.test.ts
@@ -12,7 +12,7 @@ describe("Result", () => {
     const error = Error("ERROR");
     const result = Result.error(error);
 
-    expect(result.getOrNull()).toBe(undefined);
+    expect(result.getOrNull()).toBeUndefined();
     expect(result.throwableOrNull()).toBe(error);
   });
 });

--- a/test/Result.test.ts
+++ b/test/Result.test.ts
@@ -1,0 +1,18 @@
+import { Result } from "@/models/common/Result";
+
+describe("Result", () => {
+  it("success", () => {
+    const result = Result.success(10);
+
+    expect(result.getOrNull()).toBe(10);
+    expect(result.throwableOrNull()).toBeUndefined();
+  });
+
+  it("error", () => {
+    const error = Error("ERROR");
+    const result = Result.error(error);
+
+    expect(result.getOrNull()).toBe(undefined);
+    expect(result.throwableOrNull()).toBe(error);
+  });
+});


### PR DESCRIPTION
내부를 리팩토링 했습니다. 내부에 `Failure` 클래스를 따로 빼두어 간결하게 코드를 수정했습니다.

추가로 `isFailure` getter를 구현했습니다.