### PR TITLE
[CFRS-75] 공부방 헤드폰 켜고 끄는 기능 구현

### DIFF
--- a/src/constants/socketProtocol.ts
+++ b/src/constants/socketProtocol.ts
@@ -95,6 +95,11 @@ const CONSUME_RESUME = "consumer-resume";
 const GET_PRODUCER_IDS = "getProducers";
 
 /**
+ * 클라이언트가 헤드셋을 킬 때 서버에 요청하는 프로토콜이다.
+ */
+const GET_AUDIO_PRODUCER_IDS = "get-audio-producer-ids";
+
+/**
  * 새로운 생성자가 등장했다고 서버가 클라이언트에게 전송한다.
  */
 const NEW_PRODUCER = "new-producer";
@@ -165,6 +170,7 @@ export {
   CONSUME,
   CONSUME_RESUME,
   GET_PRODUCER_IDS,
+  GET_AUDIO_PRODUCER_IDS,
   NEW_PRODUCER,
   PRODUCER_CLOSED,
   CLOSE_VIDEO_PRODUCER,

--- a/src/constants/socketProtocol.ts
+++ b/src/constants/socketProtocol.ts
@@ -117,6 +117,13 @@ const CLOSE_VIDEO_PRODUCER = "close-video-producer";
 const CLOSE_AUDIO_PRODUCER = "close-audio-producer";
 
 /**
+ * 오디오를 수신하지 않기 위해 모든 오디오 생산자를 끊는 프로토콜이다.
+ *
+ * 클라이언트가 서버에게 전달한다.
+ */
+const CLOSE_AUDIO_CONSUMERS = "close-audio-consumers";
+
+/**
  * 다른 피어가 연결을 끊었을 때 서버에서 클라이언트들에게 브로드캐스트한다.
  */
 const OTHER_PEER_DISCONNECTED = "other-peer-disconnected";
@@ -162,6 +169,7 @@ export {
   PRODUCER_CLOSED,
   CLOSE_VIDEO_PRODUCER,
   CLOSE_AUDIO_PRODUCER,
+  CLOSE_AUDIO_CONSUMERS,
   OTHER_PEER_DISCONNECTED,
   SEND_CHAT,
   START_TIMER,

--- a/src/pages/rooms/[roomId].tsx
+++ b/src/pages/rooms/[roomId].tsx
@@ -55,8 +55,8 @@ const WaitingRoom: NextPage<{
         id="audioToggle"
         onClick={() =>
           roomStore.enabledLocalAudio
-            ? roomStore.muteAudio()
-            : roomStore.unmuteAudio()
+            ? roomStore.muteMicrophone()
+            : roomStore.unmuteMicrophone()
         }
       >
         {roomStore.enabledLocalAudio ? "Mute Audio" : "Unmute Audio"}
@@ -148,12 +148,22 @@ const StudyRoom: NextPage<{ roomStore: RoomStore }> = observer(
           {enabledVideo ? "Hide Video" : "Show Video"}
         </button>
         <button
-          id="audioToggle"
+          id="microphoneToggle"
           onClick={() =>
-            enabledAudio ? roomStore.muteAudio() : roomStore.unmuteAudio()
+            enabledAudio
+              ? roomStore.muteMicrophone()
+              : roomStore.unmuteMicrophone()
           }
         >
-          {enabledAudio ? "Mute Audio" : "Unmute Audio"}
+          {enabledAudio ? "Mute Mic" : "Unmute Mic"}
+        </button>
+        <button
+          id="headphoneToggle"
+          onClick={() =>
+            true ? roomStore.muteHeadset() : roomStore.unmuteHeadset()
+          }
+        >
+          {true ? "Mute Headphone" : "Unmute Headphone"}
         </button>
         <div>
           <PomodoroTimer

--- a/src/pages/rooms/[roomId].tsx
+++ b/src/pages/rooms/[roomId].tsx
@@ -61,6 +61,16 @@ const WaitingRoom: NextPage<{
       >
         {roomStore.enabledLocalAudio ? "Mute Audio" : "Unmute Audio"}
       </button>
+      <button
+        id="headphoneToggle"
+        onClick={() =>
+          roomStore.enabledHeadset
+            ? roomStore.muteHeadset()
+            : roomStore.unmuteHeadset()
+        }
+      >
+        {roomStore.enabledHeadset ? "Mute Headset" : "Unmute Headset"}
+      </button>
       <div style={{ padding: "16px" }}>
         {roomStore.failedToJoinMessage !== undefined ? (
           <div>{roomStore.failedToJoinMessage}</div>
@@ -101,6 +111,7 @@ const StudyRoom: NextPage<{ roomStore: RoomStore }> = observer(
   ({ roomStore }) => {
     const enabledVideo = roomStore.enabledLocalVideo;
     const enabledAudio = roomStore.enabledLocalAudio;
+    const enabledHeadset = roomStore.enabledHeadset;
 
     return (
       <div>
@@ -160,10 +171,10 @@ const StudyRoom: NextPage<{ roomStore: RoomStore }> = observer(
         <button
           id="headphoneToggle"
           onClick={() =>
-            true ? roomStore.muteHeadset() : roomStore.unmuteHeadset()
+            enabledHeadset ? roomStore.muteHeadset() : roomStore.unmuteHeadset()
           }
         >
-          {true ? "Mute Headphone" : "Unmute Headphone"}
+          {enabledHeadset ? "Mute Headset" : "Unmute Headset"}
         </button>
         <div>
           <PomodoroTimer

--- a/src/service/RoomSocketService.ts
+++ b/src/service/RoomSocketService.ts
@@ -380,7 +380,6 @@ export class RoomSocketService {
         ({ id }: { id: string }) => {
           callback({ id });
           if (!this._didGetOtherProducers) {
-            console.log("뭐지????????");
             this._didGetOtherProducers = true;
             this._getRemoteProducersAndCreateReceiveTransport(device);
           }

--- a/src/service/RoomSocketService.ts
+++ b/src/service/RoomSocketService.ts
@@ -89,6 +89,8 @@ export class RoomSocketService {
   private readonly _consumingTransportIds: Set<string> = new Set();
   private _receiveTransportWrappers: ReceiveTransportWrapper[] = [];
 
+  private _didGetOtherProducers: boolean = false;
+
   constructor(private readonly _roomViewModel: RoomViewModel) {}
 
   private _requireSocket = (): Socket => {
@@ -364,13 +366,12 @@ export class RoomSocketService {
           rtpParameters: parameters.rtpParameters,
           appData: parameters.appData,
         },
-        ({ id, producersExist }: { id: string; producersExist: boolean }) => {
-          // Tell the transport that parameters were transmitted and provide it with the
-          // server side producer's id.
+        ({ id }: { id: string }) => {
           callback({ id });
-          // if producers exist, then join room
-          if (producersExist)
+          if (!this._didGetOtherProducers) {
+            this._didGetOtherProducers = true;
             this._getRemoteProducersAndCreateReceiveTransport(device);
+          }
         }
       );
     } catch (error: any) {

--- a/src/service/RoomSocketService.ts
+++ b/src/service/RoomSocketService.ts
@@ -95,7 +95,7 @@ export class RoomSocketService {
 
   private _receiveTransportWrappers: ReceiveTransportWrapper[] = [];
 
-  private _didGetOtherProducers: boolean = false;
+  private _didGetInitialProducers: boolean = false;
 
   private _mutedHeadset: boolean = false;
   private _device?: Device;
@@ -379,8 +379,8 @@ export class RoomSocketService {
         },
         ({ id }: { id: string }) => {
           callback({ id });
-          if (!this._didGetOtherProducers) {
-            this._didGetOtherProducers = true;
+          if (!this._didGetInitialProducers) {
+            this._didGetInitialProducers = true;
             this._getRemoteProducersAndCreateReceiveTransport(device);
           }
         }

--- a/src/stores/RoomStore.ts
+++ b/src/stores/RoomStore.ts
@@ -354,12 +354,13 @@ export class RoomStore implements RoomViewModel {
     this._localVideoStream = undefined;
   };
 
-  public unmuteAudio = async () => {
+  public unmuteMicrophone = async () => {
     if (this._localAudioStream !== undefined) {
       throw new InvalidStateError(
         "로컬 오디오가 있는 상태에서 오디오를 생성하려 했습니다."
       );
     }
+    this.unmuteHeadset();
     const media = await this._mediaUtil.fetchLocalMedia({ audio: true });
     await runInAction(async () => {
       const track = media.getAudioTracks()[0];
@@ -368,7 +369,7 @@ export class RoomStore implements RoomViewModel {
     });
   };
 
-  public muteAudio = () => {
+  public muteMicrophone = () => {
     if (this._localAudioStream === undefined) {
       throw new InvalidStateError(
         "로컬 오디오가 없는 상태에서 오디오를 끄려 했습니다."
@@ -377,6 +378,20 @@ export class RoomStore implements RoomViewModel {
     this._roomService.closeAudioProducer();
     this._localAudioStream.getTracks().forEach((track) => track.stop());
     this._localAudioStream = undefined;
+  };
+
+  public unmuteHeadset = () => {
+    // TODO: 구현하기
+  };
+
+  public muteHeadset = () => {
+    if (this.enabledLocalAudio) {
+      this.muteMicrophone();
+    }
+    for (const remoteAudioStream of this._remoteAudioStreamsByPeerId.values()) {
+      remoteAudioStream.getAudioTracks().forEach((audio) => audio.stop());
+    }
+    this._roomService.muteHeadset();
   };
 
   public updateChatInput = (message: string) => {

--- a/src/stores/RoomStore.ts
+++ b/src/stores/RoomStore.ts
@@ -55,6 +55,7 @@ export class RoomStore implements RoomViewModel {
 
   private _localVideoStream?: MediaStream = undefined;
   private _localAudioStream?: MediaStream = undefined;
+  private _enabledHeadset: boolean = true;
 
   // ======================= 대기실 관련 =======================
   private _waitingRoomData?: WaitingRoomData = undefined;
@@ -98,6 +99,10 @@ export class RoomStore implements RoomViewModel {
 
   public get enabledLocalAudio(): boolean {
     return this._localAudioStream !== undefined;
+  }
+
+  public get enabledHeadset(): boolean {
+    return this._enabledHeadset;
   }
 
   // ================================ 대기실 getter 시작 ================================
@@ -360,7 +365,9 @@ export class RoomStore implements RoomViewModel {
         "로컬 오디오가 있는 상태에서 오디오를 생성하려 했습니다."
       );
     }
-    this.unmuteHeadset();
+    if (!this.enabledHeadset) {
+      this.unmuteHeadset();
+    }
     const media = await this._mediaUtil.fetchLocalMedia({ audio: true });
     await runInAction(async () => {
       const track = media.getAudioTracks()[0];
@@ -381,7 +388,8 @@ export class RoomStore implements RoomViewModel {
   };
 
   public unmuteHeadset = () => {
-    // TODO: 구현하기
+    this._roomService.unmuteHeadset();
+    this._enabledHeadset = true;
   };
 
   public muteHeadset = () => {
@@ -392,6 +400,7 @@ export class RoomStore implements RoomViewModel {
       remoteAudioStream.getAudioTracks().forEach((audio) => audio.stop());
     }
     this._roomService.muteHeadset();
+    this._enabledHeadset = false;
   };
 
   public updateChatInput = (message: string) => {


### PR DESCRIPTION
- 헤드폰을 끄면 오디오 소비자를 모두 닫고 배열에서 제거합니다. 그리고 서버에 알려서 서버도 마찬가지 작업을 진행합니다.
- 헤드폰을 끄면 마이크도 같이 꺼집니다.
- 헤드폰을 끄고나서 다른 상대가 새로 접속하거나 다른 상대가 오디오를 껐다 켜도 오디오 소비자를 만들지 않습니다.
- 헤드폰을 끈 상태에서 마이크를 켜면 헤드폰도 같이 켜집니다.

https://github.com/Foundy-LLC/camstudy-webrtc-server/pull/9

https://user-images.githubusercontent.com/57604817/218450993-f77c33ec-0a6f-4677-b842-073ba5df8fea.mov

