### PR TITLE
[CFRS-107] profile image POST API 버그 수정 및 안정성 개선

### DIFF
--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -128,6 +128,15 @@ export const postProfileImage = async (
   res: NextApiResponse
 ) => {
   try {
+    const userId = req.query.userId;
+    if (typeof userId !== "string") {
+      res.status(404).send(
+        new ResponseBody({
+          message: "잘못된 query 접근입니다. 회원 ID가 문자열이 아닙니다.",
+        })
+      );
+      return;
+    }
     const multerUpload = multer({
       storage: multer.diskStorage({
         destination: function (req, file, callback) {
@@ -142,11 +151,10 @@ export const postProfileImage = async (
 
     await runMiddleware(req, res, multerUpload.single("profileImage"));
     const file = req.file;
-    const others = req.body;
     console.log(file);
 
     const signedUrl = await multipartUploader(
-      "users/" + others.fileName + ".png",
+      "users/" + userId + ".png",
       file.path
     );
     res.status(201).send(

--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -6,6 +6,7 @@ import {
 import {
   createUser,
   findUser,
+  insertUserProfileImage,
   isUserExists,
 } from "@/repository/user.repository";
 import {
@@ -157,6 +158,8 @@ export const postProfileImage = async (
       "users/" + userId + ".png",
       file.path
     );
+
+    await insertUserProfileImage(userId, signedUrl);
     res.status(201).send(
       new ResponseBody({
         message: PROFILE_IMAGE_UPDATE,


### PR DESCRIPTION
- Client에서 fileName을 꼭 userId로 지정하지 않아도 되도록 안정성 개선
- 이미지 업로드 성공시 이미지 url을 회원 db에 삽입(사용 안한다고 하여도 일단 지금은 엔티티에 속성이 있으니 넣는것이 맞아보입니다.)