### PR TITLE
[CFRS-153] 인증 이메일 재전송 구현

### DIFF
--- a/src/constants/organizationMessage.ts
+++ b/src/constants/organizationMessage.ts
@@ -19,3 +19,5 @@ export const ORGANIZATIONS_EMAIL_SEND_FAIL: string =
   "인증 이메일 발송에 실패하였습니다.";
 export const ORGANIZATIONS_EMAIL_TOKEN_NULL_ERROR: string =
   "이메일 인증 토큰이 누락되었습니다.";
+export const ORGANIZATION_EMAIL_VERIFY_DUPLICATED: string =
+  "이미 인증된 소속입니다.";

--- a/src/controller/organization.controller.ts
+++ b/src/controller/organization.controller.ts
@@ -10,9 +10,11 @@ import {
   findBelongOrganizations,
   findOrganizations,
   updateEmailVerifyStatus,
+  verifyBelong,
 } from "@/repository/organization.repository";
 import {
   BELONG_ORGANIZATIONS_GET_SUCCESS,
+  ORGANIZATION_EMAIL_VERIFY_DUPLICATED,
   ORGANIZATIONS_EMAIL_CONFIRM_SUCCESS,
   ORGANIZATIONS_EMAIL_SEND_FAIL,
   ORGANIZATIONS_EMAIL_SEND_SUCCESS,
@@ -128,6 +130,14 @@ export const setOrganizationEmail = async (
       organizationId,
       organizationName
     );
+    // 해당 소속이 이미 인증되어 있는 지 확인
+    if (await verifyBelong(userId, organizationId)) {
+      res
+        .status(409)
+        .send(
+          new ResponseBody({ message: ORGANIZATION_EMAIL_VERIFY_DUPLICATED })
+        );
+    }
     await addOrganizationEmailVerify(
       organizationsEmailRequestBody.userId,
       organizationsEmailRequestBody.email,

--- a/src/models/organization/verifyOrganization.ts
+++ b/src/models/organization/verifyOrganization.ts
@@ -1,0 +1,4 @@
+export interface VerifyOrganization {
+  email: string;
+  isAuthenticated: boolean;
+}

--- a/src/repository/organization.repository.ts
+++ b/src/repository/organization.repository.ts
@@ -3,6 +3,7 @@ import { ORGANIZATION_NUM_PER_PAGE } from "@/constants/organization.constant";
 import { belong, organization } from "@prisma/client";
 import { BelongOrganization, Organization } from "@/stores/OrganizationStore";
 import { async } from "@firebase/util";
+import { VerifyOrganization } from "@/models/organization/verifyOrganization";
 
 export const updateEmailVerifyStatus = async (
   userId: string,
@@ -22,7 +23,7 @@ export const updateEmailVerifyStatus = async (
 export const verifyBelong = async (
   userId: string,
   organizationId: string
-): Promise<boolean> => {
+): Promise<VerifyOrganization | undefined> => {
   const result = await client.belong.findUnique({
     where: {
       user_id_organization_id: {
@@ -30,9 +31,13 @@ export const verifyBelong = async (
         organization_id: organizationId,
       },
     },
+    select: {
+      email: true,
+      is_authenticated: true,
+    },
   });
-  if (result === null) return false;
-  else return true;
+  if (result == null) return undefined;
+  return { email: result.email, isAuthenticated: result.is_authenticated };
 };
 
 export const addOrganizationEmailVerify = async (
@@ -47,6 +52,22 @@ export const addOrganizationEmailVerify = async (
       email: email,
       is_authenticated: false,
     },
+  });
+};
+
+export const updateOrganizationEmailVerify = async (
+  userId: string,
+  email: string,
+  organizationId: string
+) => {
+  await client.belong.update({
+    where: {
+      user_id_organization_id: {
+        user_id: userId,
+        organization_id: organizationId,
+      },
+    },
+    data: { email: email },
   });
 };
 

--- a/src/repository/organization.repository.ts
+++ b/src/repository/organization.repository.ts
@@ -2,6 +2,7 @@ import client from "prisma/client";
 import { ORGANIZATION_NUM_PER_PAGE } from "@/constants/organization.constant";
 import { belong, organization } from "@prisma/client";
 import { BelongOrganization, Organization } from "@/stores/OrganizationStore";
+import { async } from "@firebase/util";
 
 export const updateEmailVerifyStatus = async (
   userId: string,
@@ -16,6 +17,22 @@ export const updateEmailVerifyStatus = async (
     },
     data: { is_authenticated: true },
   });
+};
+
+export const verifyBelong = async (
+  userId: string,
+  organizationId: string
+): Promise<boolean> => {
+  const result = await client.belong.findUnique({
+    where: {
+      user_id_organization_id: {
+        user_id: userId,
+        organization_id: organizationId,
+      },
+    },
+  });
+  if (result === null) return false;
+  else return true;
 };
 
 export const addOrganizationEmailVerify = async (


### PR DESCRIPTION
 ### 상세 내용
- 소속이 이미 추가돼 있으면 보내지 않음
- 이메일을 보낸 적이 없으면 DB에 추가
- 같은 이메일로 보냈으나 인증되진 않은 경우 DB는 그대로 두고 이메일만 보냄
- 다른 이메일을 입력한 경우 기존 DB의 email을 업데이트

https://user-images.githubusercontent.com/56541313/223052329-9f07ab33-2f20-47b0-87c6-4e8cbab58297.mov

