### PR TITLE
존재하지 않는 방 예외처리 구현

### DIFF
--- a/src/models/room/RoomState.ts
+++ b/src/models/room/RoomState.ts
@@ -1,5 +1,6 @@
 export enum RoomState {
   CREATED,
+  NOT_EXISTS,
   CONNECTED,
   WAITING_ROOM,
   JOINED,

--- a/src/pages/rooms/[roomId].tsx
+++ b/src/pages/rooms/[roomId].tsx
@@ -36,6 +36,8 @@ const RoomScaffold: NextPage = observer(() => {
   }
 
   switch (roomStore.state) {
+    case RoomState.NOT_EXISTS:
+      return <NotExistsPage />;
     case RoomState.CREATED:
     case RoomState.CONNECTED:
     case RoomState.WAITING_ROOM:
@@ -44,6 +46,16 @@ const RoomScaffold: NextPage = observer(() => {
       return <StudyRoom roomStore={roomStore} />;
   }
 });
+
+const NotExistsPage: NextPage = () => {
+  const router = useRouter();
+  return (
+    <>
+      존재하지 않는 방입니다.
+      <Button onClick={() => router.replace("/")}>홈으로</Button>
+    </>
+  );
+};
 
 const WaitingRoom: NextPage<{
   roomStore: RoomStore;

--- a/src/service/RoomSocketService.ts
+++ b/src/service/RoomSocketService.ts
@@ -122,7 +122,6 @@ export class RoomSocketService {
       CONNECTION_SUCCESS,
       async ({ socketId }: { socketId: string }) => {
         console.log("Connected: ", socketId);
-        await this._roomViewModel.onConnected();
         this._connectWaitingRoom(roomId);
       }
     );
@@ -132,7 +131,11 @@ export class RoomSocketService {
     this._requireSocket().emit(
       JOIN_WAITING_ROOM,
       roomId,
-      (waitingRoomData: WaitingRoomData) => {
+      (waitingRoomData?: WaitingRoomData) => {
+        if (waitingRoomData == null) {
+          this._roomViewModel.onNotExistsRoomId();
+          return;
+        }
         this._roomViewModel.onConnectedWaitingRoom(waitingRoomData);
         this._listenWaitingRoomEvents();
       }

--- a/src/stores/RoomStore.ts
+++ b/src/stores/RoomStore.ts
@@ -29,8 +29,8 @@ import { BlockedUser } from "@/models/room/BlockedUser";
 import { convertToKoreaDate } from "@/utils/DateUtil";
 
 export interface RoomViewModel {
-  onConnected: () => Promise<void>;
   onConnectedWaitingRoom: (waitingRoomData: WaitingRoomData) => void;
+  onNotExistsRoomId: () => void;
   onWaitingRoomEvent: (event: WaitingRoomEvent) => void;
   onFailedToJoin: (message: string) => void;
   onJoined: (
@@ -330,25 +330,25 @@ export class RoomStore implements RoomViewModel {
     });
   };
 
-  public onConnected = async (): Promise<void> => {
+  public onConnectedWaitingRoom = async (waitingRoomData: WaitingRoomData) => {
     const mediaStream = await this._mediaUtil.fetchLocalMedia({
       video: true,
       audio: true,
     });
     runInAction(() => {
-      this._state = RoomState.CONNECTED;
       this._localVideoStream =
         this._mediaUtil.getMediaStreamUsingFirstVideoTrackOf(mediaStream);
       this._localAudioStream =
         this._mediaUtil.getMediaStreamUsingFirstAudioTrackOf(mediaStream);
+      this._state = RoomState.WAITING_ROOM;
+      this._waitingRoomData = waitingRoomData;
+      this._masterId = waitingRoomData.masterId;
+      this._blacklist = waitingRoomData.blacklist;
     });
   };
 
-  public onConnectedWaitingRoom = (waitingRoomData: WaitingRoomData) => {
-    this._state = RoomState.WAITING_ROOM;
-    this._waitingRoomData = waitingRoomData;
-    this._masterId = waitingRoomData.masterId;
-    this._blacklist = waitingRoomData.blacklist;
+  public onNotExistsRoomId = () => {
+    this._state = RoomState.NOT_EXISTS;
   };
 
   public onWaitingRoomEvent = (event: WaitingRoomEvent) => {

--- a/test/RoomStore.test.ts
+++ b/test/RoomStore.test.ts
@@ -1,5 +1,5 @@
 import { RoomStore } from "@/stores/RoomStore";
-import { deepEqual, instance, mock, when } from "ts-mockito";
+import { instance, mock, when } from "ts-mockito";
 import { RoomState } from "@/models/room/RoomState";
 import { MediaUtil } from "@/utils/MediaUtil";
 import { PomodoroTimerState } from "@/models/room/PomodoroTimerState";
@@ -12,29 +12,6 @@ import { RoomJoiner } from "@/models/room/RoomJoiner";
 import { Auth, User } from "@firebase/auth";
 import { auth } from "@/service/firebase";
 import { RoomSocketService } from "@/service/RoomSocketService";
-
-describe("RoomStore.onConnected", () => {
-  it("should set state to CONNECTED", async () => {
-    // given
-    const mediaUtil = mock<MediaUtil>();
-    when(mediaUtil.fetchLocalMedia({ video: true, audio: true })).thenResolve(
-      mock()
-    );
-    when(
-      mediaUtil.getMediaStreamUsingFirstVideoTrackOf(deepEqual(mock()))
-    ).thenReturn(mock());
-    when(
-      mediaUtil.getMediaStreamUsingFirstAudioTrackOf(deepEqual(mock()))
-    ).thenReturn(mock());
-    const roomStore = new RoomStore(instance(mediaUtil));
-
-    // when
-    await roomStore.onConnected();
-
-    // then
-    expect(roomStore.state).toBe(RoomState.CONNECTED);
-  });
-});
 
 describe("RoomStore.onJoined", () => {
   it("should set state to JOINED", () => {

--- a/test/RoomStore.test.ts
+++ b/test/RoomStore.test.ts
@@ -53,9 +53,10 @@ describe("after invoking RoomStore.onUpdatedPomodoroTimer", () => {
 describe("RoomStore.onWaitingRoomEvent", () => {
   let roomStore: RoomStore;
 
-  beforeAll(() => {
-    roomStore = new RoomStore();
-    roomStore.onConnectedWaitingRoom({
+  beforeAll(async () => {
+    const mediaUtil: MediaUtil = mock();
+    roomStore = new RoomStore(instance(mediaUtil));
+    await roomStore.onConnectedWaitingRoom({
       joinerList: [],
       masterId: "masterId",
       capacity: MAX_ROOM_CAPACITY,
@@ -92,17 +93,21 @@ describe("RoomStore.onWaitingRoomEvent", () => {
 });
 
 describe("RoomStore.enabledJoinRoomButton", () => {
-  it("true", () => {
+  it("true", async () => {
     // given
     const id = "id";
+    const mockMediaUtil = mock<MediaUtil>();
     const mockAuth = mock<Auth>();
     const mockUser = mock<User>();
     when(mockUser.uid).thenReturn(id);
     when(mockAuth.currentUser).thenReturn(instance(mockUser));
-    const roomStore = new RoomStore(new MediaUtil(), instance(mockAuth));
+    const roomStore = new RoomStore(
+      instance(mockMediaUtil),
+      instance(mockAuth)
+    );
 
     // when
-    roomStore.onConnectedWaitingRoom({
+    await roomStore.onConnectedWaitingRoom({
       joinerList: [],
       masterId: "masterId",
       capacity: MAX_ROOM_CAPACITY,
@@ -114,17 +119,21 @@ describe("RoomStore.enabledJoinRoomButton", () => {
     expect(roomStore.enableJoinButton).toBe(true);
   });
 
-  it("should be false when current user already joined room", () => {
+  it("should be false when current user already joined room", async () => {
     // given
     const id = "id";
+    const mockMediaUtil = mock<MediaUtil>();
     const mockAuth = mock<Auth>();
     const mockUser = mock<User>();
     when(mockUser.uid).thenReturn(id);
     when(mockAuth.currentUser).thenReturn(instance(mockUser));
-    const roomStore = new RoomStore(new MediaUtil(), instance(mockAuth));
+    const roomStore = new RoomStore(
+      instance(mockMediaUtil),
+      instance(mockAuth)
+    );
 
     // when
-    roomStore.onConnectedWaitingRoom({
+    await roomStore.onConnectedWaitingRoom({
       joinerList: [{ id: id, name: "name" }],
       masterId: "masterId",
       capacity: MAX_ROOM_CAPACITY,
@@ -136,17 +145,21 @@ describe("RoomStore.enabledJoinRoomButton", () => {
     expect(roomStore.enableJoinButton).toBe(false);
   });
 
-  it("should be false when current user was blocked", () => {
+  it("should be false when current user was blocked", async () => {
     // given
     const id = "id";
+    const mockMediaUtil = mock<MediaUtil>();
     const mockAuth = mock<Auth>();
     const mockUser = mock<User>();
     when(mockUser.uid).thenReturn(id);
     when(mockAuth.currentUser).thenReturn(instance(mockUser));
-    const roomStore = new RoomStore(new MediaUtil(), instance(mockAuth));
+    const roomStore = new RoomStore(
+      instance(mockMediaUtil),
+      instance(mockAuth)
+    );
 
     // when
-    roomStore.onConnectedWaitingRoom({
+    await roomStore.onConnectedWaitingRoom({
       joinerList: [],
       masterId: "masterId",
       capacity: MAX_ROOM_CAPACITY,
@@ -226,13 +239,14 @@ describe("RoomStore.unblockUser", () => {
     // given
     const userId = "userId";
     const mockService = mock<RoomSocketService>();
+    const mediaUtil = mock<MediaUtil>();
     when(mockService.unblockUser(userId)).thenResolve();
     const roomStore = new RoomStore(
-      new MediaUtil(),
+      instance(mediaUtil),
       auth,
       instance(mockService)
     );
-    roomStore.onConnectedWaitingRoom({
+    await roomStore.onConnectedWaitingRoom({
       blacklist: [{ id: userId, name: "name" }],
       capacity: 0,
       hasPassword: false,


### PR DESCRIPTION
- onConnected 함수를 제거하고 onConnectedWaitingRoom 이 호출될 때 onConnected에서 수행하던 작업을 수행하도록 수정했습니다.
- 존재하지 않는 방 URL 접속시 존재하지 않는 방이라고 보입니다.

https://github.com/Foundy-LLC/camstudy-webrtc-server/pull/23

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/57604817/226112412-5f99e767-028a-4579-b5f7-7fec77a7befa.png">
