### PR TITLE
[CFRS-184] 친구 목록 및 요청 목록 GET API 응답 객체 통일 및 버그 수정

### DIFF
--- a/src/models/user/UserOverview.ts
+++ b/src/models/user/UserOverview.ts
@@ -4,6 +4,6 @@ export interface UserOverview {
   id: string;
   name: string;
   profileImage: string | null;
-  rankingScore: number;
+  introduce: string | null;
   status: UserStatus;
 }

--- a/src/pages/api/users/[userId]/friends.ts
+++ b/src/pages/api/users/[userId]/friends.ts
@@ -1,6 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import {
-  deleteFriend,
   getFriendList,
   sendFriendRequest,
 } from "@/controller/friend.controller";

--- a/src/pages/friends.tsx
+++ b/src/pages/friends.tsx
@@ -130,7 +130,7 @@ const FriendRequestGroup: NextPage<{ items: FriendRequestUser[] }> = observer(
 const FriendOverview: NextPage<{ item: UserOverview }> = observer(
   ({ item }) => {
     const { friendStore } = useStores();
-    const { id, name, profileImage, rankingScore, status } = item;
+    const { id, name, profileImage, introduce, status } = item;
     return (
       <>
         <Image
@@ -139,7 +139,7 @@ const FriendOverview: NextPage<{ item: UserOverview }> = observer(
           src={profileImage ? profileImage : DEFAULT_THUMBNAIL_URL}
           alt={`${name}-profileImg`}
         />
-        <h3>{name}&nbsp;</h3> <h3>랭킹점수:{rankingScore}&nbsp;</h3>
+        <h3>{name}&nbsp;</h3> <h3>자기소개: {introduce}&nbsp;</h3>
         <Image
           width={20}
           height={20}


### PR DESCRIPTION
- 응답 객체를 UserOverview로 통일했습니다. 또한 UserOverview에 존재하던 rankingScore를 제거하고 introduce를 추가했습니다. 랭킹 GET API에서는 별도의 객체를 이용하여야겠습니다.
- https://github.com/Foundy-LLC/camstudy-web/pull/79 에서 놓친 부분을 수정했습니다. 친구 목록 요청 GET API에서 응답자 목록을 반환하지 않고 요청자 목록을 반환하던 문제입니다.