### PR TITLE
명세서와 다르게 구현된 Room POST API 수정

### DIFF
--- a/src/constants/roomMessage.ts
+++ b/src/constants/roomMessage.ts
@@ -1,11 +1,6 @@
-import {
-  POMODORO_LONG_BREAK_RANGE,
-  POMODORO_LONG_INTERVAL_RANGE,
-  POMODORO_SHORT_BREAK_RANGE,
-  POMODORO_TIMER_RANGE,
-} from "@/constants/room.constant";
-
 export const ROOM_CREATE_SUCCESS: string = "방 개설을 성공했습니다.";
+export const ROOM_BODY_INVALID_ERROR_MESSAGE: string =
+  "잘못된 Body를 전송했습니다.";
 export const ROOM_DELETE_SUCCESS: string = "방을 삭제되었습니다";
 export const GET_RECENT_ROOM_SUCCESS: string =
   "최근 접속한 방 목록을 성공적으로 얻었습니다.";

--- a/src/controller/room.controller.ts
+++ b/src/controller/room.controller.ts
@@ -26,6 +26,7 @@ import { multipartUploader } from "@/service/imageUploader";
 import {
   GET_RECENT_ROOM_SUCCESS,
   GET_ROOMS_SUCCESS,
+  ROOM_BODY_INVALID_ERROR_MESSAGE,
   ROOM_CREATE_SUCCESS,
   ROOM_DELETE_SUCCESS,
   SET_ROOM_THUMBNAIL_SUCCESS,
@@ -140,7 +141,14 @@ export const getRecentRooms = async (
 
 export const postRoom = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    await createRoom(new RoomCreateRequestBody(req.body._room));
+    const body = req.body as RoomCreateRequestBody | null;
+    if (body == null) {
+      res
+        .status(400)
+        .send(new ResponseBody({ message: ROOM_BODY_INVALID_ERROR_MESSAGE }));
+      return;
+    }
+    await createRoom(body);
     res.status(201).send(new ResponseBody({ message: ROOM_CREATE_SUCCESS }));
   } catch (e) {
     if (typeof e === "string") {

--- a/src/models/room/RoomCreateRequestBody.ts
+++ b/src/models/room/RoomCreateRequestBody.ts
@@ -14,10 +14,25 @@ import {
 } from "@/utils/room.validator";
 
 export class RoomCreateRequestBody {
-  private readonly _room: Room;
+  readonly masterId: string;
+  readonly title: string;
+  readonly password: string | undefined;
+  readonly timer: number;
+  readonly shortBreak: number;
+  readonly longBreak: number;
+  readonly longBreakInterval: number;
+  readonly expiredAt: Date;
+
   constructor(room: Room) {
-    this._room = room;
-    this._validateId();
+    this.masterId = room.masterId;
+    this.title = room.title;
+    this.timer = room.timer;
+    this.password = room.password;
+    this.shortBreak = room.shortBreak;
+    this.longBreak = room.longBreak;
+    this.longBreakInterval = room.longBreakInterval;
+    this.expiredAt = room.expiredAt;
+
     this._validateMasterId();
     this._validatePassword();
     this._validateTitle();
@@ -27,34 +42,36 @@ export class RoomCreateRequestBody {
     this._validateLongInterval();
     this._validateExpiredAt();
   }
-  get room() {
-    return this._room;
-  }
-  private _validateId = () => {
-    validateId(this._room.id);
-  };
+
   private _validateMasterId = () => {
-    validateMasterId(this._room.masterId);
+    validateMasterId(this.masterId);
   };
+
   private _validatePassword = () => {
-    validatePassword(this._room.password);
+    validatePassword(this.password);
   };
+
   private _validateTitle = () => {
-    validateTitle(this._room.title);
+    validateTitle(this.title);
   };
+
   private _validateTimer = () => {
-    validateTimerLength(this._room.timer);
+    validateTimerLength(this.timer);
   };
+
   private _validateShortBreak = () => {
-    validateShortBreak(this._room.shortBreak);
+    validateShortBreak(this.shortBreak);
   };
+
   private _validateLongBreak = () => {
-    validateLongBreak(this._room.longBreak);
+    validateLongBreak(this.longBreak);
   };
+
   private _validateLongInterval = () => {
-    validateLongInterval(this._room.longBreakInterval);
+    validateLongInterval(this.longBreakInterval);
   };
+
   private _validateExpiredAt = () => {
-    validateExpiredAt(this._room.expiredAt);
+    validateExpiredAt(this.expiredAt);
   };
 }

--- a/src/repository/room.repository.ts
+++ b/src/repository/room.repository.ts
@@ -2,7 +2,6 @@ import prisma from "../../prisma/client";
 import client from "prisma/client";
 import { RoomOverview } from "@/models/room/RoomOverview";
 import { RoomCreateRequestBody } from "@/models/room/RoomCreateRequestBody";
-import { Room } from "@/stores/RoomListStore";
 import {
   MAX_RECENT_ROOM_NUM,
   MAX_ROOM_CAPACITY,
@@ -10,6 +9,7 @@ import {
 } from "@/constants/room.constant";
 import { room } from "@prisma/client";
 import { RoomDeleteRequestBody } from "@/models/room/RoomDeleteRequestBody";
+import { uuidv4 } from "@firebase/util";
 
 export const findRoomById = async (roomId: string): Promise<room | null> => {
   return await prisma.room.findUnique({
@@ -95,19 +95,17 @@ export const findRecentRooms = async (userId: string) => {
 };
 
 export const createRoom = async (body: RoomCreateRequestBody) => {
-  const room: Room = body.room;
   await client.room.create({
     data: {
-      id: room.id,
-      master_id: room.masterId,
-      title: room.title,
-      thumbnail: room.thumbnail,
-      password: room.password,
-      timer: room.timer,
-      short_break: room.shortBreak,
-      long_break: room.longBreak,
-      long_break_interval: room.longBreakInterval,
-      expired_at: room.expiredAt,
+      id: uuidv4(),
+      master_id: body.masterId,
+      title: body.title,
+      password: body.password,
+      timer: body.timer,
+      short_break: body.shortBreak,
+      long_break: body.longBreak,
+      long_break_interval: body.longBreakInterval,
+      expired_at: body.expiredAt,
     },
   });
 };

--- a/src/service/room.service.ts
+++ b/src/service/room.service.ts
@@ -2,7 +2,6 @@ import { Result } from "@/models/common/Result";
 import { RoomCreateRequestBody } from "@/models/room/RoomCreateRequestBody";
 import { RoomOverview } from "@/models/room/RoomOverview";
 import { Room } from "@/stores/RoomListStore";
-import { RoomDeleteRequestBody } from "@/models/room/RoomDeleteRequestBody";
 import { fetchAbsolute } from "@/utils/fetchAbsolute";
 
 const HEADER = {

--- a/test/RoomCreateRequestBody.test.ts
+++ b/test/RoomCreateRequestBody.test.ts
@@ -53,15 +53,6 @@ describe("RoomCreateRequestBody success validation", () => {
 });
 
 describe("RoomCreateRequestBody Error validation", () => {
-  it("should throw error when roomId is null", async () => {
-    //given
-    const room: Room = new Room("");
-    //when
-    await expect(() => {
-      new RoomCreateRequestBody(room);
-    }).toThrow(NO_ROOM_ID_ERROR_MESSAGE); //then
-  });
-
   it("should throw error when masterId is null", async () => {
     //given
     const room: Room = new Room("123", "");


### PR DESCRIPTION
- 명세서는 Body 자체가 Request 객체였으나 실제로는 { _body: ... }로 감싸야했습니다. 
- uuid를 클라이언트가 전달하지 않고 서버쪽에서 직접 생성하도록 했습니다.