### PR TITLE
[CFRS-203] roomOverview 분리

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,6 +26,7 @@ export const Header: NextPage<{ userId: string }> = observer(({ userId }) => {
         className={`${headerStyles["header-image"]}`}
         src={logo}
         alt={"brand_logo"}
+        priority={true}
       ></Image>
       <RecentRoomList userId={userId}></RecentRoomList>
       <div className={`${headerStyles["header-user-section"]}`}>
@@ -59,7 +60,11 @@ const RecentRoomList: NextPage<{ userId: string }> = observer(({ userId }) => {
   useEffect(() => {
     roomListStore.fetchRecentRooms(userId);
   }, []);
-  const recentRoomList = roomListStore.roomOverviews;
+  let recentRoomList = roomListStore.recentRoomOverviews;
+
+  if (recentRoomList.length > 5) {
+    recentRoomList = recentRoomList.slice(0, 5);
+  }
 
   const joinRecentRoom = (roomId: string) => {
     Router.push(`rooms/${roomId}`);

--- a/src/pages/rooms.tsx
+++ b/src/pages/rooms.tsx
@@ -15,6 +15,7 @@ import roomListIcon from "/public/room/roomListIcon.png";
 import { UserOverview } from "@/models/user/UserOverview";
 import InfiniteScroll from "react-infinite-scroll-component";
 import { SideMenuBar } from "@/components/SideMenuBar";
+import { Header } from "@/components/Header";
 
 const RoomItemGroup: NextPage<{ items: RoomOverview[] }> = observer(
   ({ items }) => {
@@ -264,10 +265,27 @@ const RoomList: NextPage = observer(() => {
         {/*    }*/}
         {/*  }}*/}
         {/*></input>*/}
-        <RoomItemGroup items={roomListStore.roomOverviews} />
-        {roomListStore.errorMessage === undefined ? null : (
-          <h3>{roomListStore.errorMessage}</h3>
-        )}
+
+        <section className={"box"}>
+          <div className={"box-header-margin"}>
+            <Header userId={user.uid} />
+          </div>
+          <div className={"box-contents-margin"}>
+            <div className={"box-contents"}>
+              <div className={"box-contents-side-menu"}>
+                <SideMenuBar userId={user.uid}></SideMenuBar>
+              </div>
+              <div className={"box-contents-item"}>
+                {/* TODO(민성): UserProfileImage와 중복되는 코드 제거하기.*/}
+                <RoomItemGroup items={roomListStore.roomOverviews} />
+                {roomListStore.errorMessage === undefined ? null : (
+                  <h3>{roomListStore.errorMessage}</h3>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
         {/*{RoomsInfo && <p id="getResponse">{RoomsInfo}</p>}*/}
       </div>
     </>

--- a/src/stores/RoomListStore.ts
+++ b/src/stores/RoomListStore.ts
@@ -2,9 +2,6 @@ import { makeAutoObservable, runInAction } from "mobx";
 import { RootStore } from "@/stores/RootStore";
 import roomService, { RoomService } from "@/service/room.service";
 import { RoomOverview } from "@/models/room/RoomOverview";
-import React from "react";
-import expect from "expect";
-import roomId from "@/pages/rooms/[roomId]";
 
 //TODO(건우) 값을 임시로 할당하여 수정 필요
 export class Room {
@@ -36,6 +33,7 @@ export class RoomListStore {
   private _isExistNextPage: boolean = true;
   private _rooms: Room[] = [];
   private _roomOverviews: RoomOverview[] = [];
+  private _recentRoomOverviews: RoomOverview[] = [];
   private _pageNum: number = 0;
   private _isSuccessCreate: boolean = false;
   private _isSuccessGet: boolean = false;
@@ -68,6 +66,10 @@ export class RoomListStore {
     return this._roomOverviews;
   }
 
+  get recentRoomOverviews(): RoomOverview[] {
+    return this._recentRoomOverviews;
+  }
+
   get imageUrl(): string {
     return this._imageUrl;
   }
@@ -97,6 +99,7 @@ export class RoomListStore {
     date.setDate(date.getDate() + this._roomExpirate);
     this._tempRoom = { ...this._tempRoom, expiredAt: date };
   }
+
   public setMasterId = (masterId: string) => {
     this._tempRoom = { ...this._tempRoom, masterId: masterId };
   };
@@ -145,7 +148,7 @@ export class RoomListStore {
       runInAction(() => {
         this._initErrorMessage();
         this._isSuccessGet = true;
-        this._roomOverviews = getRecentRoomsResult.getOrNull()!!;
+        this._recentRoomOverviews = getRecentRoomsResult.getOrNull()!!;
       });
     } else {
       runInAction(() => {


### PR DESCRIPTION
문제점 
- 기존에는 방 목록 불러오기, 최근 접속한 방 목록 불러오기한 결과를  같은 변수인 roomOverview에 저장했음.
- 따라서 스터디 룸 화면에 가면 방 목록이 잘 보이지만 헤더에 최근 접속한 방 목록에도 덮여 쓰여짐

해결
- 변수를 따로 만듬