### PR TITLE
[CFRS-224] 수확한 작물 리스트 GET API 명세서대로 수정 및 Crop 코드 개선

### DIFF
--- a/src/constants/CropGrade.ts
+++ b/src/constants/CropGrade.ts
@@ -1,8 +1,0 @@
-export const cropGrade = {
-  NOT_FRESH: "not_fresh",
-  FRESH: "fresh",
-  SILVER: "silver",
-  GOLD: "gold",
-  DIAMOND: "diamond",
-} as const;
-export type CROP_GRADE = (typeof cropGrade)[keyof typeof cropGrade];

--- a/src/models/crop/Crop.ts
+++ b/src/models/crop/Crop.ts
@@ -1,6 +1,8 @@
-import { CROP_GRADE } from "@/constants/CropGrade";
+import { crops_type, fruit_grade } from "@prisma/client";
 
 export interface Crop {
-  type: string;
-  grade: CROP_GRADE;
+  type: crops_type;
+  grade: fruit_grade;
+  plantedAt: Date;
+  harvestedAt: Date;
 }

--- a/src/models/crop/HarvestedCrop.ts
+++ b/src/models/crop/HarvestedCrop.ts
@@ -1,6 +1,6 @@
 import { crops_type, fruit_grade } from "@prisma/client";
 
-export interface Crop {
+export interface HarvestedCrop {
   type: crops_type;
   grade: fruit_grade;
   plantedAt: Date;

--- a/src/pages/api/crops/[userId].ts
+++ b/src/pages/api/crops/[userId].ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { setCrop } from "@/controller/crop.controller";
+import { fetchHarvestedCrops } from "@/controller/crop.controller";
 
 export default async function cropsHandler(
   req: NextApiRequest,
@@ -7,8 +7,8 @@ export default async function cropsHandler(
 ) {
   const { method } = req;
   switch (method) {
-    case "POST":
-      await setCrop(req, res);
+    case "GET":
+      await fetchHarvestedCrops(req, res);
       break;
     default:
       res.status(405).end(`Method ${method} Not Allowed`);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/router";
 import { verifyUserToken } from "@/service/verifyUserToken";
 import { fetchAbsolute } from "@/utils/fetchAbsolute";
 import { useStores } from "@/stores/context";
-import { Crop } from "@/models/crop/Crop";
+import { HarvestedCrop } from "@/models/crop/HarvestedCrop";
 import { Layout } from "@/components/Layout";
 import { crops_type } from "@prisma/client";
 
@@ -23,7 +23,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   return await verifyUserToken(ctx);
 };
 
-const HarvestedCropGroup: NextPage<{ items: Crop[] }> = observer(
+const HarvestedCropGroup: NextPage<{ items: HarvestedCrop[] }> = observer(
   ({ items }) => {
     return (
       <>

--- a/src/repository/crop.repository.ts
+++ b/src/repository/crop.repository.ts
@@ -4,11 +4,13 @@ import prisma from "../../prisma/client";
 import { CropHarvestRequestBody } from "@/models/crop/CropHarvestRequestBody";
 import { Prisma } from ".prisma/client";
 import { crops, fruit_grade } from "@prisma/client";
-import { Crop } from "@/models/crop/Crop";
+import { HarvestedCrop } from "@/models/crop/HarvestedCrop";
 import { CropDeleteRequestBody } from "@/models/crop/CropDeleteRequestBody";
 import { STANDARD_END_HOUR_OF_DAY } from "@/constants/common";
 
-export const getHarvestedCrops = async (userId: string): Promise<Crop[]> => {
+export const getHarvestedCrops = async (
+  userId: string
+): Promise<HarvestedCrop[]> => {
   const harvestedCrops = await prisma.crops.findMany({
     where: {
       user_id: userId,
@@ -20,7 +22,7 @@ export const getHarvestedCrops = async (userId: string): Promise<Crop[]> => {
       harvested_at: "desc",
     },
   });
-  return harvestedCrops.map((crop: crops) => {
+  return harvestedCrops.map<HarvestedCrop>((crop: crops) => {
     return {
       type: crop.type,
       grade: crop.grade!,

--- a/src/repository/crop.repository.ts
+++ b/src/repository/crop.repository.ts
@@ -3,7 +3,7 @@ import { CropCreateRequestBody } from "@/models/crop/CropCreateRequestBody";
 import prisma from "../../prisma/client";
 import { CropHarvestRequestBody } from "@/models/crop/CropHarvestRequestBody";
 import { Prisma } from ".prisma/client";
-import { fruit_grade } from "@prisma/client";
+import { crops, fruit_grade } from "@prisma/client";
 import { Crop } from "@/models/crop/Crop";
 import { CropDeleteRequestBody } from "@/models/crop/CropDeleteRequestBody";
 import { STANDARD_END_HOUR_OF_DAY } from "@/constants/common";
@@ -20,10 +20,12 @@ export const getHarvestedCrops = async (userId: string): Promise<Crop[]> => {
       harvested_at: "desc",
     },
   });
-  return harvestedCrops.map((crop) => {
+  return harvestedCrops.map((crop: crops) => {
     return {
       type: crop.type,
       grade: crop.grade!,
+      plantedAt: crop.planted_at,
+      harvestedAt: crop.harvested_at!,
     };
   });
 };

--- a/src/service/crop.service.ts
+++ b/src/service/crop.service.ts
@@ -1,12 +1,12 @@
 import { UidValidationRequestBody } from "@/models/common/UidValidationRequestBody";
 import { Result } from "@/models/common/Result";
 import { fetchAbsolute } from "@/utils/fetchAbsolute";
-import { Crop } from "@/models/crop/Crop";
+import { HarvestedCrop } from "@/models/crop/HarvestedCrop";
 
 export class CropService {
   public getHarvestedCrops = async (
     userId: string
-  ): Promise<Result<Crop[]>> => {
+  ): Promise<Result<HarvestedCrop[]>> => {
     try {
       const requestBody = new UidValidationRequestBody(userId);
       const response = await fetchAbsolute(

--- a/src/stores/CropStore.ts
+++ b/src/stores/CropStore.ts
@@ -1,5 +1,5 @@
 import { RootStore } from "@/stores/RootStore";
-import { Crop } from "@/models/crop/Crop";
+import { HarvestedCrop } from "@/models/crop/HarvestedCrop";
 import { CropService, cropService } from "@/service/crop.service";
 import { UserStore } from "@/stores/UserStore";
 import { NO_USER_STORE_ERROR_MESSAGE } from "@/constants/message";
@@ -8,7 +8,7 @@ import { makeAutoObservable, runInAction } from "mobx";
 export class CropStore {
   readonly rootStore: RootStore;
   private _userStore: UserStore;
-  private _harvestedCrops: Crop[] = [];
+  private _harvestedCrops: HarvestedCrop[] = [];
   constructor(
     root: RootStore,
     private readonly _cropService: CropService = cropService


### PR DESCRIPTION
- 수확한 작물 리스트 GET API를 변경된 명세서대로 수정했습니다.
- CropGrade라는 객체가 중복되어 존재하여 하나를 제거하고 우선 엔티티의 enum을 곧바로 참조하도록 했습니다.(곧바로 엔티티의 enum을 참조해도 괜찮을지 아직 모르겠네요)
- Crop의 이름이 혼동을 줄 수 있어서 이름을 HarvestedCrop이라고 변경했습니다.