### PR TITLE
방 생성 POST API 성공 응답 및 태그 로직 수정

### DIFF
--- a/src/constants/roomMessage.ts
+++ b/src/constants/roomMessage.ts
@@ -17,6 +17,8 @@ export const BLACKLIST_CANNOT_JOIN_ROOM_MESSAGE: string =
   "방 접근이 차단되어 입장할 수 없습니다.";
 
 export const NO_ROOM_ID_ERROR_MESSAGE: string = "방 아이디가 누락 되었습니다";
+export const NO_ROOM_TAG_ERROR_MESSAGE: string =
+  "방 태그는 최소 1개 이상입니다.";
 export const NO_ROOM_MASTER_ID_ERROR_MESSAGE: string =
   "방장 아이디가 누락 되었습니다";
 export const NO_ROOM_TITLE_ERROR_MESSAGE: string =

--- a/src/controller/room.controller.ts
+++ b/src/controller/room.controller.ts
@@ -26,6 +26,7 @@ import { multipartUploader } from "@/service/imageUploader";
 import {
   GET_RECENT_ROOM_SUCCESS,
   GET_ROOMS_SUCCESS,
+  NO_ROOM_TAG_ERROR_MESSAGE,
   ROOM_BODY_INVALID_ERROR_MESSAGE,
   ROOM_CREATE_SUCCESS,
   ROOM_DELETE_SUCCESS,
@@ -41,7 +42,6 @@ import {
   createTagsIfNotExists,
   findTagIdsByTagName,
 } from "@/repository/tag.repository";
-import { Room } from "@/stores/RoomListStore";
 
 export const getRoomAvailability = async (
   req: NextApiRequest,
@@ -166,6 +166,12 @@ export const postRoom = async (req: NextApiRequest, res: NextApiResponse) => {
       body.expiredAt,
       body.tags
     );
+    if (requestBody.tags.length === 0) {
+      res
+        .status(400)
+        .send(new ResponseBody({ message: NO_ROOM_TAG_ERROR_MESSAGE }));
+      return;
+    }
     await createTagsIfNotExists(requestBody.tags);
     const tagIds = await findTagIdsByTagName(requestBody.tags);
 

--- a/src/controller/room.controller.ts
+++ b/src/controller/room.controller.ts
@@ -42,6 +42,8 @@ import {
   createTagsIfNotExists,
   findTagIdsByTagName,
 } from "@/repository/tag.repository";
+import { RoomOverview } from "@/models/room/RoomOverview";
+import { MAX_ROOM_CAPACITY } from "@/constants/room.constant";
 
 export const getRoomAvailability = async (
   req: NextApiRequest,
@@ -174,9 +176,23 @@ export const postRoom = async (req: NextApiRequest, res: NextApiResponse) => {
     }
     await createTagsIfNotExists(requestBody.tags);
     const tagIds = await findTagIdsByTagName(requestBody.tags);
-
-    await createRoom(requestBody, tagIds);
-    res.status(201).send(new ResponseBody({ message: ROOM_CREATE_SUCCESS }));
+    const roomEntity = await createRoom(requestBody, tagIds);
+    res.status(201).send(
+      new ResponseBody({
+        message: ROOM_CREATE_SUCCESS,
+        data: new RoomOverview(
+          roomEntity.id,
+          roomEntity.master_id,
+          roomEntity.title,
+          roomEntity.password != null,
+          roomEntity.thumbnail,
+          0,
+          MAX_ROOM_CAPACITY,
+          [],
+          requestBody.tags
+        ),
+      })
+    );
   } catch (e) {
     if (typeof e === "string") {
       res.status(400).send(new ResponseBody({ message: e }));

--- a/src/controller/room.controller.ts
+++ b/src/controller/room.controller.ts
@@ -103,7 +103,7 @@ export const getRooms = async (req: NextApiRequest, res: NextApiResponse) => {
     }
     const roomsGetBody = new RoomsGetRequest(page, query);
     const result = await findRooms(roomsGetBody.pageNum, roomsGetBody.query);
-    res.status(201).json(
+    res.status(200).json(
       new ResponseBody({
         data: result,
         message: GET_ROOMS_SUCCESS,

--- a/src/repository/room.repository.ts
+++ b/src/repository/room.repository.ts
@@ -145,11 +145,11 @@ export const findRecentRooms = async (
 export const createRoom = async (
   body: RoomCreateRequestBody,
   tags: { id: string }[]
-) => {
+): Promise<room> => {
   const tagIdsDto: { tag_id: string }[] = tags!.map((tag) => {
     return { tag_id: tag.id };
   });
-  await client.room.create({
+  return await client.room.create({
     data: {
       id: uuidv4(),
       master_id: body.masterId,

--- a/src/repository/tag.repository.ts
+++ b/src/repository/tag.repository.ts
@@ -41,6 +41,18 @@ export const findTagIdsByTagName = async (
   });
 };
 
+export const findUserTags = async (userId: string): Promise<string[]> => {
+  const tags = await prisma.user_tag.findMany({
+    where: {
+      user_id: userId,
+    },
+    include: {
+      tag: true,
+    },
+  });
+  return tags.map((t) => t.tag.name);
+};
+
 export const findSimilarTags = async (pageNum: number, name?: string) => {
   return await client.tag.findMany({
     skip: pageNum * TAG_NUM_PER_PAGE,


### PR DESCRIPTION
- 방 생성을 성공했을 때 응답에 생성된 방의 RoomOverview 데이터를 포함하도록 했습니다.
- 방 태그를 설정하지 않은 요청의 경우 생성자 회원의 태그를 방태그로 입력하도록 했습니다. 예전 기획서에 그렇게 되어있었기 때문입니다~!(제가 한번 수정했었다가 다시 돌려놓았습니다..)