### PR TITLE
[CFRS-245] 태그 삭제 api 추가

### DIFF
--- a/src/constants/tag.constant.ts
+++ b/src/constants/tag.constant.ts
@@ -1,2 +1,9 @@
 export const TAG_NUM_PER_PAGE = 3;
 export const TAGS_GET_SUCCESS: string = "태그 조회에 성공했습니다";
+export const TAGS_DELETE_SUCCESS: string =
+  "회원 관심태그를 성공적으로 삭제했습니다.";
+export const TAG_NAME_NULL_ERROR: string = "태그 이름이 비어있습니다.";
+export const TAG_ID_NOT_FOUND_ERROR: string =
+  "해당 태그의 id를 찾을 수 없습니다.";
+export const TAG_NOT_REGISTERED_ERROR: string =
+  "해당 태그가 회원의 관심 태그로 등록되어 있지 않습니다.";

--- a/src/controller/tag.controller.ts
+++ b/src/controller/tag.controller.ts
@@ -4,9 +4,19 @@ import {
   SERVER_INTERNAL_ERROR_MESSAGE,
 } from "@/constants/message";
 import { ResponseBody } from "@/models/common/ResponseBody";
-import { findSimilarTags } from "@/repository/tag.repository";
+import {
+  deleteTageById,
+  findSimilarTags,
+  findTagIdByTagName,
+} from "@/repository/tag.repository";
 import { TagGetRequestBody } from "@/models/welcome/TagGetRequestBody";
-import { TAGS_GET_SUCCESS } from "@/constants/tag.constant";
+import {
+  TAG_NOT_REGISTERED_ERROR,
+  TAGS_DELETE_SUCCESS,
+  TAGS_GET_SUCCESS,
+} from "@/constants/tag.constant";
+import { tagDeleteRequestBody } from "@/models/tag/TagDeleteRequestBody";
+import { Prisma } from "@prisma/client";
 
 export const getTags = async (req: NextApiRequest, res: NextApiResponse) => {
   const { name, page } = req.query;
@@ -31,6 +41,37 @@ export const getTags = async (req: NextApiRequest, res: NextApiResponse) => {
   } catch (e) {
     if (typeof e === "string") {
       res.status(400).send(new ResponseBody({ message: e }));
+      return;
+    }
+    res
+      .status(500)
+      .send(new ResponseBody({ message: SERVER_INTERNAL_ERROR_MESSAGE }));
+  }
+};
+
+export const deleteTag = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const { userId, tag } = req.query;
+    if (typeof userId !== "string" || typeof tag !== "string")
+      throw REQUEST_QUERY_ERROR;
+    const requestBody = new tagDeleteRequestBody(userId, tag);
+    const tagId = await findTagIdByTagName(requestBody.tag);
+    await deleteTageById(userId, tagId);
+    res.status(200).json(
+      new ResponseBody({
+        message: TAGS_DELETE_SUCCESS,
+      })
+    );
+  } catch (e) {
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError &&
+      e.code === "P2025"
+    ) {
+      res.status(400).send(
+        new ResponseBody({
+          message: TAG_NOT_REGISTERED_ERROR,
+        })
+      );
       return;
     }
     res

--- a/src/controller/tag.controller.ts
+++ b/src/controller/tag.controller.ts
@@ -15,7 +15,7 @@ import {
   TAGS_DELETE_SUCCESS,
   TAGS_GET_SUCCESS,
 } from "@/constants/tag.constant";
-import { tagDeleteRequestBody } from "@/models/tag/TagDeleteRequestBody";
+import { TagDeleteRequestBody } from "@/models/tag/TagDeleteRequestBody";
 import { Prisma } from "@prisma/client";
 
 export const getTags = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -54,7 +54,7 @@ export const deleteTag = async (req: NextApiRequest, res: NextApiResponse) => {
     const { userId, tag } = req.query;
     if (typeof userId !== "string" || typeof tag !== "string")
       throw REQUEST_QUERY_ERROR;
-    const requestBody = new tagDeleteRequestBody(userId, tag);
+    const requestBody = new TagDeleteRequestBody(userId, tag);
     const tagId = await findTagIdByTagName(requestBody.tag);
     await deleteTageById(userId, tagId);
     res.status(200).json(

--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -33,7 +33,7 @@ import { MAX_IMAGE_BYTE_SIZE } from "@/constants/image.constant";
 import { UidValidationRequestBody } from "@/models/common/UidValidationRequestBody";
 import { SimilarNamedFriendsGetRequestBody } from "@/models/friend/SimilarNamedFriendsGetRequestBody";
 import { SEARCH_SIMILAR_NAMED_USERS_SUCCESS } from "@/constants/FriendMessage";
-import { updateUserRequestBody } from "@/models/user/UpdateUserRequestBody";
+import { userUpdateRequestBody } from "@/models/user/UserUpdateRequestBody";
 
 export const getUser = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -159,7 +159,7 @@ export const postUser = async (req: NextApiRequest, res: NextApiResponse) => {
 export const updateUser = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const { userId, nickName, introduce, tags } = req.body;
-    const requestBody = new updateUserRequestBody(
+    const requestBody = new userUpdateRequestBody(
       userId,
       nickName,
       introduce,

--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -33,7 +33,7 @@ import { MAX_IMAGE_BYTE_SIZE } from "@/constants/image.constant";
 import { UidValidationRequestBody } from "@/models/common/UidValidationRequestBody";
 import { SimilarNamedFriendsGetRequestBody } from "@/models/friend/SimilarNamedFriendsGetRequestBody";
 import { SEARCH_SIMILAR_NAMED_USERS_SUCCESS } from "@/constants/FriendMessage";
-import { userUpdateRequestBody } from "@/models/user/UserUpdateRequestBody";
+import { UserUpdateRequestBody } from "@/models/user/UserUpdateRequestBody";
 
 export const getUser = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -159,7 +159,7 @@ export const postUser = async (req: NextApiRequest, res: NextApiResponse) => {
 export const updateUser = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const { userId, nickName, introduce, tags } = req.body;
-    const requestBody = new userUpdateRequestBody(
+    const requestBody = new UserUpdateRequestBody(
       userId,
       nickName,
       introduce,

--- a/src/models/tag/TagDeleteRequestBody.ts
+++ b/src/models/tag/TagDeleteRequestBody.ts
@@ -1,7 +1,7 @@
 import { TAG_NAME_NULL_ERROR } from "@/constants/tag.constant";
 import { validateUid } from "@/utils/user.validator";
 
-export class tagDeleteRequestBody {
+export class TagDeleteRequestBody {
   constructor(readonly userId: string, readonly tag: string) {
     validateUid(userId);
     if (tag == null) throw TAG_NAME_NULL_ERROR;

--- a/src/models/tag/TagDeleteRequestBody.ts
+++ b/src/models/tag/TagDeleteRequestBody.ts
@@ -1,0 +1,9 @@
+import { TAG_NAME_NULL_ERROR } from "@/constants/tag.constant";
+import { validateUid } from "@/utils/user.validator";
+
+export class tagDeleteRequestBody {
+  constructor(readonly userId: string, readonly tag: string) {
+    validateUid(userId);
+    if (tag == null) throw TAG_NAME_NULL_ERROR;
+  }
+}

--- a/src/models/user/UserUpdateRequestBody.ts
+++ b/src/models/user/UserUpdateRequestBody.ts
@@ -4,9 +4,8 @@ import {
   validateUserName,
   validateUserTags,
 } from "@/utils/user.validator";
-import { User } from "@/models/user/User";
 
-export class updateUserRequestBody {
+export class userUpdateRequestBody {
   constructor(
     readonly userId: string,
     readonly nickName: string,

--- a/src/models/user/UserUpdateRequestBody.ts
+++ b/src/models/user/UserUpdateRequestBody.ts
@@ -5,7 +5,7 @@ import {
   validateUserTags,
 } from "@/utils/user.validator";
 
-export class userUpdateRequestBody {
+export class UserUpdateRequestBody {
   constructor(
     readonly userId: string,
     readonly nickName: string,

--- a/src/pages/api/users/[userId]/tag.ts
+++ b/src/pages/api/users/[userId]/tag.ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { deleteTag } from "@/controller/tag.controller";
+
+export default async function tagHandler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { method } = req;
+  switch (method) {
+    case "DELETE":
+      await deleteTag(req, res);
+      break;
+    default:
+      res.status(405).end(`Method ${method} Not Allowed`);
+  }
+}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -6,8 +6,6 @@ import { ResponseBody } from "@/models/common/ResponseBody";
 import { UserProfileImage } from "@/components/UserProfileImage";
 import { NOT_FOUND_USER_MESSAGE } from "@/constants/message";
 import { useRouter } from "next/router";
-import { Header } from "@/components/Header";
-import { SideMenuBar } from "@/components/SideMenuBar";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "@/service/firebase";
 import profileStyles from "@/styles/profile.module.scss";
@@ -259,7 +257,7 @@ const OrganizationForm: NextPage = observer(() => {
 const UserProfile: NextPage = observer(() => {
   const router = useRouter();
   const [user, loading] = useAuthState(auth);
-  const { roomListStore, organizationStore } = useStores();
+  const { roomListStore, profileStore } = useStores();
   const fetcher = (args: string) => fetch(args).then((res) => res.json());
   const { data, isLoading } = useSWR<ResponseBody<User>>(
     `/api/users/${user?.uid}`,
@@ -377,6 +375,18 @@ const UserProfile: NextPage = observer(() => {
           <h1>태그: {profile.tags}</h1>
           <h1>소개: {profile.introduce}</h1>
           <h1>소속: {profile.organizations}</h1>
+          <input type={"text"} id="tag-input"></input>
+          <button
+            onClick={() => {
+              const tag = document.getElementById(
+                "tag-input"
+              ) as HTMLInputElement;
+              if (tag.value == null) return;
+              profileStore.deleteTag(tag.value);
+            }}
+          >
+            태그 삭제
+          </button>
         </div>
       </Layout>
       <style jsx>

--- a/src/repository/tag.repository.ts
+++ b/src/repository/tag.repository.ts
@@ -5,7 +5,10 @@ import tagWhereInput = Prisma.tagWhereInput;
 import { SEARCH_USERS_MAX_NUM } from "@/constants/user.constant";
 import client from "../../prisma/client";
 import { ORGANIZATION_NUM_PER_PAGE } from "@/constants/organization.constant";
-import { TAG_NUM_PER_PAGE } from "@/constants/tag.constant";
+import {
+  TAG_ID_NOT_FOUND_ERROR,
+  TAG_NUM_PER_PAGE,
+} from "@/constants/tag.constant";
 
 export const createTagsIfNotExists = async (tagNames: string[]) => {
   const data: { id: string; name: string }[] = tagNames.map((tagName) => {
@@ -41,6 +44,19 @@ export const findTagIdsByTagName = async (
   });
 };
 
+export const findTagIdByTagName = async (tagName: string): Promise<string> => {
+  const result = await prisma.tag.findUnique({
+    where: {
+      name: tagName,
+    },
+    select: {
+      id: true,
+    },
+  });
+  if (result == null) throw TAG_ID_NOT_FOUND_ERROR;
+  return result.id;
+};
+
 export const findUserTags = async (userId: string): Promise<string[]> => {
   const tags = await prisma.user_tag.findMany({
     where: {
@@ -60,5 +76,13 @@ export const findSimilarTags = async (pageNum: number, name?: string) => {
     where: { name: { startsWith: name } },
     orderBy: { name: "asc" },
     select: { name: true },
+  });
+};
+
+export const deleteTageById = async (userId: string, tagId: string) => {
+  return await client.user_tag.delete({
+    where: {
+      tag_id_user_id: { tag_id: tagId, user_id: userId },
+    },
   });
 };

--- a/src/service/profile.service.ts
+++ b/src/service/profile.service.ts
@@ -2,7 +2,9 @@ import { Result } from "@/models/common/Result";
 import { User } from "@/models/user/User";
 import { UidValidationRequestBody } from "@/models/common/UidValidationRequestBody";
 import { fetchAbsolute } from "@/utils/fetchAbsolute";
-import { updateUserRequestBody } from "@/models/user/UpdateUserRequestBody";
+import { userUpdateRequestBody } from "@/models/user/UserUpdateRequestBody";
+import { validateUid } from "@/utils/user.validator";
+import { tagDeleteRequestBody } from "@/models/tag/TagDeleteRequestBody";
 
 const HEADER = {
   "Content-Type": "application/json",
@@ -33,7 +35,7 @@ export class ProfileService {
     tags: string[]
   ) => {
     try {
-      const RequestBody = new updateUserRequestBody(
+      const RequestBody = new userUpdateRequestBody(
         userId,
         nickName,
         introduce,
@@ -44,6 +46,29 @@ export class ProfileService {
         body: JSON.stringify(RequestBody),
         headers: HEADER,
       });
+      if (response.ok) {
+        return Result.createSuccessUsingResponseData(response);
+      } else {
+        return Result.createErrorUsingResponseMessage(response);
+      }
+    } catch (e) {
+      return Result.createErrorUsingException(e);
+    }
+  };
+
+  public deleteTag = async (
+    userId: string,
+    tag: string
+  ): Promise<Result<string>> => {
+    try {
+      const RequestBody = new tagDeleteRequestBody(userId, tag);
+      const response = await fetchAbsolute(
+        `api/users/${RequestBody.userId}/tag?tag=${RequestBody.tag}`,
+        {
+          method: "DELETE",
+          headers: HEADER,
+        }
+      );
       if (response.ok) {
         return Result.createSuccessUsingResponseData(response);
       } else {

--- a/src/service/profile.service.ts
+++ b/src/service/profile.service.ts
@@ -2,9 +2,9 @@ import { Result } from "@/models/common/Result";
 import { User } from "@/models/user/User";
 import { UidValidationRequestBody } from "@/models/common/UidValidationRequestBody";
 import { fetchAbsolute } from "@/utils/fetchAbsolute";
-import { userUpdateRequestBody } from "@/models/user/UserUpdateRequestBody";
+import { UserUpdateRequestBody } from "@/models/user/UserUpdateRequestBody";
 import { validateUid } from "@/utils/user.validator";
-import { tagDeleteRequestBody } from "@/models/tag/TagDeleteRequestBody";
+import { TagDeleteRequestBody } from "@/models/tag/TagDeleteRequestBody";
 
 const HEADER = {
   "Content-Type": "application/json",
@@ -35,7 +35,7 @@ export class ProfileService {
     tags: string[]
   ) => {
     try {
-      const RequestBody = new userUpdateRequestBody(
+      const RequestBody = new UserUpdateRequestBody(
         userId,
         nickName,
         introduce,
@@ -61,7 +61,7 @@ export class ProfileService {
     tag: string
   ): Promise<Result<string>> => {
     try {
-      const RequestBody = new tagDeleteRequestBody(userId, tag);
+      const RequestBody = new TagDeleteRequestBody(userId, tag);
       const response = await fetchAbsolute(
         `api/users/${RequestBody.userId}/tag?tag=${RequestBody.tag}`,
         {

--- a/src/stores/ProfileStore.ts
+++ b/src/stores/ProfileStore.ts
@@ -55,10 +55,12 @@ export class ProfileStore {
   }
 
   importUserProfile = (profile: User) => {
-    this._nickName = profile.name;
-    this._introduce = profile.introduce;
-    this._tags = profile.tags;
-    this._organizations = profile.organizations;
+    runInAction(() => {
+      this._nickName = profile.name;
+      this._introduce = profile.introduce;
+      this._tags = profile.tags;
+      this._organizations = profile.organizations;
+    });
   };
 
   public onChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -142,6 +144,35 @@ export class ProfileStore {
             tags: this._tags!,
             organizations: this._userOverview!.organizations,
           };
+        });
+      } else {
+        runInAction(() => {
+          throw new Error(result.throwableOrNull()!.message);
+        });
+      }
+    } catch (e) {
+      runInAction(() => {
+        if (e instanceof Error) this._errorMessage = e.message;
+      });
+    }
+  };
+
+  public deleteTag = async (tagName: string) => {
+    try {
+      if (!this.userStore.currentUser) {
+        throw new Error(NO_USER_STORE_ERROR_MESSAGE);
+      }
+      const result = await this._profileService.deleteTag(
+        this.userStore.currentUser.id,
+        tagName
+      );
+      if (result.isSuccess) {
+        runInAction(() => {
+          this._userOverview = {
+            ...this._userOverview!,
+            tags: this._userOverview!.tags.filter((tag) => tag !== tagName),
+          };
+          console.log(tagName, "삭제 성공");
         });
       } else {
         runInAction(() => {


### PR DESCRIPTION
### 상세 내용
- 유저 아이디와 태그 이름을 api에 전달하여 관심 태그에서 삭제
- api 구현을 위해 프론트에는 간단하게만 구현했습니다.

https://user-images.githubusercontent.com/56541313/235317779-43086616-d574-464c-9c62-73542da44008.mov

삭제할 태그를 입력하고 태그 삭제 버튼을 누르면 우측 db화면의 user_tag가 삭제되는 것을 보실 수 있습니다.
