### PR TITLE
[CFRS-365] `friendStatus`에 `REQUEST_RECEIVED` 상태 값 추가 및 API 수정

### DIFF
--- a/src/constants/FriendMessage.ts
+++ b/src/constants/FriendMessage.ts
@@ -12,6 +12,8 @@ export const NOT_FOUND_FRIEND_REQUEST_ERROR =
 export const INVALID_FRIEND_REQUEST_USER_ID =
   "요청자 회원의 ID가 누락되었습니다.";
 export const FRIEND_REQUEST_ID_ERROR = "본인에게 친구 요청을 보낼 수 없습니다.";
+export const ALREADY_RECEIVED_FRIEND_REQUEST =
+  "친구 요청을 받은 상태에서 친구 요청을 보낼 수 없습니다.";
 export const FRIEND_CANCEL_REQUEST_ID_ERROR =
   "본인에게 보낸 친구 요청이 존재할 수 없습니다.";
 export const FRIEND_REQUESTS_GET_SUCCESS =

--- a/src/constants/FriendMessage.ts
+++ b/src/constants/FriendMessage.ts
@@ -12,8 +12,8 @@ export const NOT_FOUND_FRIEND_REQUEST_ERROR =
 export const INVALID_FRIEND_REQUEST_USER_ID =
   "요청자 회원의 ID가 누락되었습니다.";
 export const FRIEND_REQUEST_ID_ERROR = "본인에게 친구 요청을 보낼 수 없습니다.";
-export const ALREADY_RECEIVED_FRIEND_REQUEST =
-  "친구 요청을 받은 상태에서 친구 요청을 보낼 수 없습니다.";
+export const DIRECTLY_APPROVE_FRIEND_REQUEST =
+  "이미 친구 요청을 받은 상태라 바로 친구가 되었어요.";
 export const FRIEND_CANCEL_REQUEST_ID_ERROR =
   "본인에게 보낸 친구 요청이 존재할 수 없습니다.";
 export const FRIEND_REQUESTS_GET_SUCCESS =

--- a/src/constants/FriendStatus.ts
+++ b/src/constants/FriendStatus.ts
@@ -1,6 +1,7 @@
 export const friendStatus = {
   NONE: "NONE",
   REQUESTED: "REQUESTED",
+  REQUEST_RECEIVED: "REQUEST_RECEIVED",
   ACCEPTED: "ACCEPTED",
 } as const;
 export type FRIEND_STATUS = (typeof friendStatus)[keyof typeof friendStatus];

--- a/src/controller/friend.controller.ts
+++ b/src/controller/friend.controller.ts
@@ -7,6 +7,7 @@ import {
   fetchFriendList,
   fetchFriendRequests,
   fetchRecommendedFriends,
+  hasFriendRequest,
 } from "@/repository/friend.repository";
 import { ResponseBody } from "@/models/common/ResponseBody";
 import {
@@ -26,6 +27,7 @@ import {
   FRIEND_LIST_GET_SUCCESS,
   PAGE_NUM_OUT_OF_RANGE_ERROR,
   INVALID_FRIEND_REQUEST_USER_ID,
+  ALREADY_RECEIVED_FRIEND_REQUEST,
 } from "@/constants/FriendMessage";
 import { Prisma } from ".prisma/client";
 import PrismaClientKnownRequestError = Prisma.PrismaClientKnownRequestError;
@@ -48,6 +50,14 @@ export const sendFriendRequest = async (
     if (userId === targetUserId) {
       throw FRIEND_REQUEST_ID_ERROR;
     }
+    const didReceiveRequest = await hasFriendRequest({
+      acceptorId: userId,
+      requesterId: targetUserId,
+    });
+    if (didReceiveRequest) {
+      throw ALREADY_RECEIVED_FRIEND_REQUEST;
+    }
+
     await addFriend(friendRequestBody.userId, friendRequestBody.targetUserId);
     res.status(201).send(new ResponseBody({ message: FRIEND_REQUEST_SUCCESS }));
   } catch (e) {

--- a/src/controller/friend.controller.ts
+++ b/src/controller/friend.controller.ts
@@ -34,6 +34,7 @@ import PrismaClientKnownRequestError = Prisma.PrismaClientKnownRequestError;
 import { FriendGetOverviewsBody } from "@/models/friend/FriendGetOverviewsBody";
 import { FriendRequestsGetBody } from "@/models/friend/FriendRequestsGetBody";
 import { UidValidationRequestBody } from "@/models/common/UidValidationRequestBody";
+import { friendStatus } from "@/constants/FriendStatus";
 
 export const sendFriendRequest = async (
   req: NextApiRequest,
@@ -59,14 +60,22 @@ export const sendFriendRequest = async (
         friendRequestBody.targetUserId,
         friendRequestBody.userId
       );
-      res
-        .status(200)
-        .send(new ResponseBody({ message: DIRECTLY_APPROVE_FRIEND_REQUEST }));
+      res.status(200).send(
+        new ResponseBody({
+          message: DIRECTLY_APPROVE_FRIEND_REQUEST,
+          data: friendStatus.ACCEPTED,
+        })
+      );
       return;
     }
 
     await addFriend(friendRequestBody.userId, friendRequestBody.targetUserId);
-    res.status(201).send(new ResponseBody({ message: FRIEND_REQUEST_SUCCESS }));
+    res.status(201).send(
+      new ResponseBody({
+        message: FRIEND_REQUEST_SUCCESS,
+        data: friendStatus.REQUESTED,
+      })
+    );
   } catch (e) {
     if (typeof e === "string") {
       res.status(400).send(new ResponseBody({ message: e }));

--- a/src/controller/friend.controller.ts
+++ b/src/controller/friend.controller.ts
@@ -27,7 +27,7 @@ import {
   FRIEND_LIST_GET_SUCCESS,
   PAGE_NUM_OUT_OF_RANGE_ERROR,
   INVALID_FRIEND_REQUEST_USER_ID,
-  ALREADY_RECEIVED_FRIEND_REQUEST,
+  DIRECTLY_APPROVE_FRIEND_REQUEST,
 } from "@/constants/FriendMessage";
 import { Prisma } from ".prisma/client";
 import PrismaClientKnownRequestError = Prisma.PrismaClientKnownRequestError;
@@ -55,7 +55,14 @@ export const sendFriendRequest = async (
       requesterId: targetUserId,
     });
     if (didReceiveRequest) {
-      throw ALREADY_RECEIVED_FRIEND_REQUEST;
+      await approveFriendRequest(
+        friendRequestBody.targetUserId,
+        friendRequestBody.userId
+      );
+      res
+        .status(200)
+        .send(new ResponseBody({ message: DIRECTLY_APPROVE_FRIEND_REQUEST }));
+      return;
     }
 
     await addFriend(friendRequestBody.userId, friendRequestBody.targetUserId);

--- a/src/models/user/User.ts
+++ b/src/models/user/User.ts
@@ -5,7 +5,7 @@ export interface User {
   readonly name: string;
   readonly profileImage?: string;
   readonly consecutiveStudyDays: number;
-  readonly requestHistory?: FRIEND_STATUS;
+  readonly requestHistory: FRIEND_STATUS;
   readonly introduce: string | null;
   readonly organizations: Array<string>;
   readonly tags: Array<string>;

--- a/src/repository/friend.repository.ts
+++ b/src/repository/friend.repository.ts
@@ -3,6 +3,25 @@ import { UserOverview } from "@/models/user/UserOverview";
 import { UserStatus } from "@/models/user/UserStatus";
 import { FRIEND_NUM_PER_PAGE } from "@/constants/friend.constant";
 import _ from "lodash";
+
+export const hasFriendRequest = async ({
+  acceptorId,
+  requesterId,
+}: {
+  acceptorId: string;
+  requesterId: string;
+}): Promise<boolean> => {
+  const request = await client.friend.findUnique({
+    where: {
+      requester_id_acceptor_id: {
+        requester_id: requesterId,
+        acceptor_id: acceptorId,
+      },
+    },
+  });
+  return request != null;
+};
+
 export const addFriend = async (userId: string, targetUserId: string) => {
   await client.friend.create({
     data: {

--- a/src/repository/user.repository.ts
+++ b/src/repository/user.repository.ts
@@ -58,7 +58,7 @@ export const findUser = async (
         select: { accepted: true },
       },
       friend_friend_requester_idTouser_account: {
-        where: { acceptor_id: userId },
+        where: { acceptor_id: requesterId },
         select: { accepted: true },
       },
       belong: {

--- a/src/repository/user.repository.ts
+++ b/src/repository/user.repository.ts
@@ -112,7 +112,7 @@ export const isUserExists = async (userId: string): Promise<boolean> => {
  */
 export const getSimilarNamedUsers = async (
   userName: string,
-  userId: string
+  requesterUserId: string
 ): Promise<{ maxPage: number; users: UserSearchOverview[] }> => {
   // const removeSpace = userName.replace(/ /g, "");
   // const splitName = removeSpace.split("#");
@@ -122,7 +122,7 @@ export const getSimilarNamedUsers = async (
       where: {
         name: { contains: splitName[0] },
         id: { contains: splitName[1] },
-        NOT: { id: userId },
+        NOT: { id: requesterUserId },
       },
     }),
     prisma.user_account.findMany({
@@ -130,7 +130,7 @@ export const getSimilarNamedUsers = async (
       where: {
         name: { contains: splitName[0] },
         id: { contains: splitName[1] },
-        NOT: { id: userId },
+        NOT: { id: requesterUserId },
       },
       select: {
         id: true,
@@ -138,11 +138,11 @@ export const getSimilarNamedUsers = async (
         introduce: true,
         profile_image: true,
         friend_friend_acceptor_idTouser_account: {
-          where: { requester_id: userId },
+          where: { requester_id: requesterUserId },
           select: { accepted: true },
         },
         friend_friend_requester_idTouser_account: {
-          where: { acceptor_id: userId },
+          where: { acceptor_id: requesterUserId },
           select: { accepted: true },
         },
         status: true,

--- a/src/stores/ProfileStore.ts
+++ b/src/stores/ProfileStore.ts
@@ -268,6 +268,7 @@ export class ProfileStore {
           this._userOverview = {
             id: this._userOverview!.id,
             name: this._nickName!,
+            requestHistory: "NONE",
             consecutiveStudyDays: this._userOverview!.consecutiveStudyDays,
             introduce: this._introduce!,
             tags: this._tags!,


### PR DESCRIPTION
- `friendStatus`에 `REQUEST_RECEIVED` 상태 값을 추가했습니다.
- 친구 요청 POST API에서 친구 요청을 받은 회원에게 친구 요청을 하는 경우 곧바로 친구가 되도록 했습니다.
- 친구 요청 POST API의 응답에 friendStatus를 포함하도록 했습니다.
- 프론트 UI는 작업을 해주시면 됩니다.